### PR TITLE
MultiTokenParachainStaking - Use PairedOrLiquidityToken to add or rem…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14449,30 +14449,6 @@ dependencies = [
 ]
 
 [[patch.unused]]
-name = "artemis-asset"
-version = "0.1.1"
-
-[[patch.unused]]
-name = "artemis-core"
-version = "0.1.1"
-
-[[patch.unused]]
-name = "artemis-erc20-app"
-version = "0.1.1"
-
-[[patch.unused]]
-name = "artemis-eth-app"
-version = "0.1.1"
-
-[[patch.unused]]
-name = "artemis-ethereum"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "pallet-verifier"
-version = "0.1.1"
-
-[[patch.unused]]
 name = "beefy-gadget"
 version = "4.0.0-dev"
 
@@ -14927,6 +14903,30 @@ version = "5.0.0-dev"
 [[patch.unused]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
+
+[[patch.unused]]
+name = "artemis-asset"
+version = "0.1.1"
+
+[[patch.unused]]
+name = "artemis-core"
+version = "0.1.1"
+
+[[patch.unused]]
+name = "artemis-erc20-app"
+version = "0.1.1"
+
+[[patch.unused]]
+name = "artemis-eth-app"
+version = "0.1.1"
+
+[[patch.unused]]
+name = "artemis-ethereum"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "pallet-verifier"
+version = "0.1.1"
 
 [[patch.unused]]
 name = "beefy-gadget"

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -28,13 +28,13 @@ substrate-fixed = { git = "https://github.com/encointer/substrate-fixed", defaul
 
 pallet-xyk = { default-features = false, git = "https://github.com/mangata-finance/mangata-node", branch = "mangata-dev-v4" }
 mangata-primitives = { git = "https://github.com/mangata-finance/mangata-node", branch = "mangata-dev-v4", default-features = false }
-orml-tokens = { default-features = false, version = '0.4.1-dev', git = "https://github.com/mangata-finance/open-runtime-module-library", branch = "mangata-dev" }
+orml-tokens = { default-features = false, version = '0.4.1-dev', git = "https://github.com/mangata-finance/open-runtime-module-library", branch = "mangata-dev-v4" }
 
 
 [dev-dependencies]
 similar-asserts = "1.1.0"
 
-orml-traits = { default-features = false, version = "0.4.1-dev", git = "https://github.com/mangata-finance/open-runtime-module-library", branch = "mangata-dev" }
+orml-traits = { default-features = false, version = "0.4.1-dev", git = "https://github.com/mangata-finance/open-runtime-module-library", branch = "mangata-dev-v4" }
 pallet-assets-info = { default-features = false, git = "https://github.com/mangata-finance/mangata-node", branch = "mangata-dev-v4" }
 sp-core = { git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev-v4" }
 sp-io = { git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev-v4" }

--- a/pallets/parachain-staking/src/inflation.rs
+++ b/pallets/parachain-staking/src/inflation.rs
@@ -15,8 +15,7 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Helper methods for computing issuance based on inflation
-use crate::pallet::{Balance, Config, Pallet, TokenId, Get, MultiTokenCurrency};
-use frame_support::traits::Currency;
+use crate::pallet::{Balance, Config, Pallet, Get, MultiTokenCurrency};
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -178,23 +178,30 @@ impl Valuate for TestTokenValuator {
 
 	type CurrencyId = TokenId;
 
+	fn get_liquidity_asset(
+        first_asset_id: Self::CurrencyId,
+        _second_asset_id: Self::CurrencyId,
+    ) -> Result<TokenId, DispatchError> {
+		Ok(first_asset_id/100)
+	}
+
 	fn get_liquidity_token_mga_pool(
-		liquidity_token_id: Self::CurrencyId,
+		_liquidity_token_id: Self::CurrencyId,
 	) -> Result<(Self::CurrencyId, Self::CurrencyId), DispatchError> {
 		unimplemented!("Not required in tests!")
 	}
 
 	fn valuate_liquidity_token(
-		liquidity_token_id: Self::CurrencyId,
-		liquidity_token_amount: Self::Balance,
+		_liquidity_token_id: Self::CurrencyId,
+		_liquidity_token_amount: Self::Balance,
 	) -> Self::Balance {
 		unimplemented!("Not required in tests!")
 	}
 
 	fn scale_liquidity_by_mga_valuation(
-		mga_valuation: Self::Balance,
-		liquidity_token_amount: Self::Balance,
-		mga_token_amount: Self::Balance,
+		_mga_valuation: Self::Balance,
+		_liquidity_token_amount: Self::Balance,
+		_mga_token_amount: Self::Balance,
 	) -> Self::Balance {
 		unimplemented!("Not required in tests!")
 	}

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -28,7 +28,7 @@ use crate::mock::{
 use crate::{
 	assert_eq_events, assert_event_emitted, assert_last_event, Bond, CandidateBondChange,
 	CandidateBondRequest, CollatorStatus, DelegationChange, DelegationRequest, DelegatorAdded,
-	Error, Event, Range, CollatorSnapshot, OrderedSet
+	Error, Event, Range, PairedOrLiquidityToken
 };
 use frame_support::{assert_noop, assert_ok};
 use sp_runtime::{traits::Zero, DispatchError, Perbill, Percent};
@@ -4672,7 +4672,7 @@ fn adding_removing_staking_token_works() {
 			assert_noop!(Stake::join_candidates(Origin::signed(7), 10u128, 7u32, 100u32), Error::<Test>::StakingLiquidityTokenNotListed);
 			
 			// Add 3 as a staking token
-			assert_ok!(Stake::add_staking_liquidity_token(Origin::root(), 3u32, 100u32));
+			assert_ok!(Stake::add_staking_liquidity_token(Origin::root(), PairedOrLiquidityToken::Liquidity(3u32), 100u32));
 			assert_ok!(Stake::join_candidates(Origin::signed(3), 10u128, 3u32, 100u32));
 			assert_eq!(Stake::staking_liquidity_tokens().get(&3), Some(&None));
 			// Check that the rest remain the same
@@ -4700,12 +4700,12 @@ fn adding_removing_staking_token_works() {
 			assert_noop!(Stake::join_candidates(Origin::signed(7), 10u128, 7u32, 100u32), Error::<Test>::StakingLiquidityTokenNotListed);
 			
 			// Adding same liquidity token doesn't work
-			assert_noop!(Stake::add_staking_liquidity_token(Origin::root(), 3u32, 100u32), Error::<Test>::StakingLiquidityTokenAlreadyListed);
+			assert_noop!(Stake::add_staking_liquidity_token(Origin::root(), PairedOrLiquidityToken::Liquidity(3u32), 100u32), Error::<Test>::StakingLiquidityTokenAlreadyListed);
 			// Remove a liquidity not yet added - noop
-			assert_noop!(Stake::remove_staking_liquidity_token(Origin::root(), 4u32, 100u32), Error::<Test>::StakingLiquidityTokenNotListed);
+			assert_noop!(Stake::remove_staking_liquidity_token(Origin::root(), PairedOrLiquidityToken::Liquidity(4u32), 100u32), Error::<Test>::StakingLiquidityTokenNotListed);
 			
 			// Remove a liquidity token
-			assert_ok!(Stake::remove_staking_liquidity_token(Origin::root(), 3u32, 100u32));
+			assert_ok!(Stake::remove_staking_liquidity_token(Origin::root(), PairedOrLiquidityToken::Liquidity(3u32), 100u32));
 			// Candidate cannot join using it.
 			assert_noop!(Stake::join_candidates(Origin::signed(10), 10u128, 3u32, 100u32), Error::<Test>::StakingLiquidityTokenNotListed);
 			
@@ -4715,10 +4715,10 @@ fn adding_removing_staking_token_works() {
 			assert_eq!(Stake::staking_liquidity_tokens().get(&3), None);
 			
 			// Add more staking tokens
-			assert_ok!(Stake::add_staking_liquidity_token(Origin::root(), 4u32, 100u32));
-			assert_ok!(Stake::add_staking_liquidity_token(Origin::root(), 5u32, 100u32));
-			assert_ok!(Stake::add_staking_liquidity_token(Origin::root(), 6u32, 100u32));
-			assert_ok!(Stake::add_staking_liquidity_token(Origin::root(), 7u32, 100u32));
+			assert_ok!(Stake::add_staking_liquidity_token(Origin::root(), PairedOrLiquidityToken::Liquidity(4u32), 100u32));
+			assert_ok!(Stake::add_staking_liquidity_token(Origin::root(), PairedOrLiquidityToken::Liquidity(5u32), 100u32));
+			assert_ok!(Stake::add_staking_liquidity_token(Origin::root(), PairedOrLiquidityToken::Liquidity(6u32), 100u32));
+			assert_ok!(Stake::add_staking_liquidity_token(Origin::root(), PairedOrLiquidityToken::Liquidity(7u32), 100u32));
 
 			// Candidates can join using the newly added tokens
 			assert_ok!(Stake::join_candidates(Origin::signed(4), 10u128, 4u32, 100u32));
@@ -4860,7 +4860,7 @@ fn token_valuations_works() {
 			Event::NewRound(5, 1, 6, 230),];
 		assert_eq_events!(expected.clone());
 
-		assert_ok!(Stake::remove_staking_liquidity_token(Origin::root(), 3u32, 100u32));
+		assert_ok!(Stake::remove_staking_liquidity_token(Origin::root(), PairedOrLiquidityToken::Liquidity(3u32), 100u32));
 
 		roll_to(10);
 
@@ -4892,3 +4892,30 @@ fn token_valuations_works() {
 		});
 }
 
+#[test]
+fn paired_or_liquidity_token_works() {
+	ExtBuilder::default()
+		.with_default_staking_token(vec![
+			(1, 100),
+			(2, 100),
+			(3, 100),
+			(4, 100),
+			(5, 100),
+		])
+		.with_default_token_candidates(vec![(1, 20), (2, 20)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(Stake::add_staking_liquidity_token(Origin::root(), PairedOrLiquidityToken::Paired(7000u32), 100u32));
+			assert_eq!(Stake::staking_liquidity_tokens().get(&70), Some(&None));
+
+			assert_ok!(Stake::add_staking_liquidity_token(Origin::root(), PairedOrLiquidityToken::Liquidity(700u32), 100u32));
+			assert_eq!(Stake::staking_liquidity_tokens().get(&700), Some(&None));
+
+			assert_ok!(Stake::remove_staking_liquidity_token(Origin::root(), PairedOrLiquidityToken::Liquidity(70u32), 100u32), );
+			assert_eq!(Stake::staking_liquidity_tokens().get(&70), None);
+
+			assert_ok!(Stake::remove_staking_liquidity_token(Origin::root(), PairedOrLiquidityToken::Paired(70000u32), 100u32));
+			assert_eq!(Stake::staking_liquidity_tokens().get(&700), None);
+
+		});
+}


### PR DESCRIPTION
Use PairedOrLiquidityToken enum to add or remove staking tokens from the registry.

This affects the API as the two extrinsics now use the enum instead of a TokenId to determine which staking token to add/remove.